### PR TITLE
Change SWIG's FP type from float to double

### DIFF
--- a/swig/simanneal.i
+++ b/swig/simanneal.i
@@ -75,13 +75,13 @@ namespace std {
             if len(db_locs[0]) == 3:
                 dbs = IntVectorVector(db_locs)
             elif len(db_locs[0]) == 2:
-                dbs = FloatPairVector(db_locs)
+                dbs = DoublePairVector(db_locs)
             else:
                 raise Exception('db_locs[0] must have a length of 2 or 3.')
             self.setDBLocs(dbs)
 
         def set_v_ext(self, v_ext):
-            self.pySetVExt(FloatVector(v_ext))
+            self.pySetVExt(DoubleVector(v_ext))
 
         def set_param(self, pname, pval):
             try:


### PR DESCRIPTION
In ```global.h``` the FP type is defined to be ```double```, while the wrapper was using ```float```. This small change fixes that and makes the provided example file terminate without error. 